### PR TITLE
Revert `ResourceBounds` field to `u128`.

### DIFF
--- a/src/starknet/resource_bounds.rs
+++ b/src/starknet/resource_bounds.rs
@@ -6,7 +6,7 @@ use starknet_types_core::felt::Felt;
 pub struct ResourceBounds {
     pub resource: Felt,
     pub max_amount: u64,
-    pub max_price_per_unit: u64,
+    pub max_price_per_unit: u128,
 }
 
 impl ResourceBounds {
@@ -14,7 +14,7 @@ impl ResourceBounds {
         Value::Struct(vec![
             Value::Felt(self.resource),
             Value::U64(self.max_amount),
-            Value::U64(self.max_price_per_unit),
+            Value::U128(self.max_price_per_unit),
         ])
     }
 }


### PR DESCRIPTION
The field is defined in Cairo as an `u128`.