### PR TITLE
Implement more libfuncs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -103,6 +103,7 @@ mod test {
 
     use cairo_lang_compiler::CompilerConfig;
     use cairo_lang_starknet::compile::compile_path;
+    use cairo_lang_starknet_classes::contract_class::version_id_from_serialized_sierra_program;
     use sierra_emu::{starknet::StubSyscallHandler, ContractExecutionResult, VirtualMachine};
 
     #[test]
@@ -121,11 +122,15 @@ mod test {
 
         let sierra_program = contract.extract_sierra_program().unwrap();
 
+        let (sierra_version, _) =
+            version_id_from_serialized_sierra_program(&contract.sierra_program).unwrap();
+
         let entry_point = contract.entry_points_by_type.external.first().unwrap();
 
         let mut vm = VirtualMachine::new_starknet(
             sierra_program.clone().into(),
             &contract.entry_points_by_type,
+            sierra_version,
         );
 
         let calldata = [2.into()];
@@ -162,6 +167,9 @@ mod test {
         )
         .unwrap();
 
+        let (sierra_version, _) =
+            version_id_from_serialized_sierra_program(&contract.sierra_program).unwrap();
+
         let sierra_program = contract.extract_sierra_program().unwrap();
 
         let entry_point = contract.entry_points_by_type.constructor.first().unwrap();
@@ -169,6 +177,7 @@ mod test {
         let mut vm = VirtualMachine::new_starknet(
             sierra_program.clone().into(),
             &contract.entry_points_by_type,
+            sierra_version,
         );
 
         let calldata = [2.into()];

--- a/src/value.rs
+++ b/src/value.rs
@@ -90,6 +90,12 @@ impl Value {
                 index: 0,
                 payload: Box::new(Value::default_for_type(registry, &info.variants[0])),
             },
+            CoreTypeConcrete::Struct(info) => Value::Struct(
+                info.members
+                    .iter()
+                    .map(|member| Value::default_for_type(registry, member))
+                    .collect(),
+            ),
             x => panic!("type {:?} has no default value implementation", x.info()),
         }
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -85,6 +85,11 @@ impl Value {
             CoreTypeConcrete::Uint16(_) => Value::U16(0),
             CoreTypeConcrete::Uint128(_) => Value::U128(0),
             CoreTypeConcrete::Felt252(_) => Value::Felt(0.into()),
+            CoreTypeConcrete::Enum(info) => Value::Enum {
+                self_ty: type_id.clone(),
+                index: 0,
+                payload: Box::new(Value::default_for_type(registry, &info.variants[0])),
+            },
             x => panic!("type {:?} has no default value implementation", x.info()),
         }
     }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -117,9 +117,9 @@ impl VirtualMachine {
                         .iter()
                         .chain(entry_points.external.iter())
                         .chain(entry_points.l1_handler.iter())
-                        .map(|id| {
+                        .map(|x| {
                             (
-                                program.funcs[id.function_idx].id.clone(),
+                                FunctionId::new(x.function_idx as u64),
                                 [(CostTokenType::Const, ENTRY_POINT_COST)].into(),
                             )
                         })

--- a/src/vm/uint252.rs
+++ b/src/vm/uint252.rs
@@ -168,5 +168,7 @@ pub fn eval_square_root(
     let lhs = u256_to_biguint(lhs_lo, lhs_hi);
     let sqrt = lhs.sqrt();
 
-    EvalAction::NormalBranch(0, smallvec![range_check, u256_to_value(sqrt)])
+    let sqrt_lo: u128 = sqrt.clone().try_into().unwrap();
+
+    EvalAction::NormalBranch(0, smallvec![range_check, Value::U128(sqrt_lo)])
 }

--- a/src/vm/uint252.rs
+++ b/src/vm/uint252.rs
@@ -19,7 +19,7 @@ pub fn eval(
     match selector {
         Uint256Concrete::IsZero(info) => eval_is_zero(registry, info, args),
         Uint256Concrete::Divmod(info) => eval_divmod(registry, info, args),
-        Uint256Concrete::SquareRoot(_) => todo!(),
+        Uint256Concrete::SquareRoot(info) => eval_square_root(registry, info, args),
         Uint256Concrete::InvModN(info) => eval_inv_mod_n(registry, info, args),
     }
 }
@@ -149,4 +149,24 @@ pub fn eval_divmod(
             Value::Unit
         ],
     )
+}
+
+pub fn eval_square_root(
+    _registry: &ProgramRegistry<CoreType, CoreLibfunc>,
+    _info: &SignatureOnlyConcreteLibfunc,
+    args: Vec<Value>,
+) -> EvalAction {
+    let [range_check @ Value::Unit, Value::Struct(lhs)]: [Value; 2] = args.try_into().unwrap()
+    else {
+        panic!()
+    };
+
+    let [Value::U128(lhs_lo), Value::U128(lhs_hi)]: [Value; 2] = lhs.try_into().unwrap() else {
+        panic!()
+    };
+
+    let lhs = u256_to_biguint(lhs_lo, lhs_hi);
+    let sqrt = lhs.sqrt();
+
+    EvalAction::NormalBranch(0, smallvec![range_check, u256_to_value(sqrt)])
 }


### PR DESCRIPTION
- Fixes gas issue (similar to what was done in Native: https://github.com/lambdaclass/cairo_native/pull/1078)
- Adds u256 sqrt libfunc
- Adds some default types implementations.