### PR TITLE
Fix gas usage

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -38,10 +38,12 @@ pub enum Value {
     FeltDict {
         ty: ConcreteTypeId,
         data: HashMap<Felt, Self>,
+        count: u64,
     },
     FeltDictEntry {
         ty: ConcreteTypeId,
         data: HashMap<Felt, Self>,
+        count: u64,
         key: Felt,
     },
     EcPoint {


### PR DESCRIPTION
When squashing a dictionary, we need to refund the gas for all the dict gets that don't insert a new element.

```
refund = (access_count - dictionary_length) * DICT_GAS_REFUND_PER_ACCESS
```